### PR TITLE
Allow for running untitled files + path agnostic commands

### DIFF
--- a/Support/gomate.rb
+++ b/Support/gomate.rb
@@ -22,6 +22,9 @@ module Go
     opts = {:use_hashbang => false, :version_args => ['version'], :version_regex => /\Ago version (.*)/}
     opts[:verb] = options[:verb] if options[:verb]
 
+    # Default to running against directory, which in go should be the package.
+    # Doesn't hold for "go run", which needs to be executed against the file.
+    # The same will happend if directory is not set.
     directory = ENV['TM_DIRECTORY']
     if directory
       opts[:chdir] = directory
@@ -30,14 +33,7 @@ module Go
     if command == 'run' || !directory
       args.push(ENV['TM_FILEPATH'])
     else
-      # Default to running against directory, which in go should be the package
-      # Useful for more cases, like install and build
-      # Assumes a standard setup and may not function with all pkg managers
-      opts[:chdir] = ENV['TM_DIRECTORY']
-      pkg_length = ENV['GOPATH'].length + 4 # GOPATH + /src/
-      go_pkg = ENV['TM_DIRECTORY'][pkg_length..-1] # subtract above, is pkg name
       args.push("-v") # list packages being operated on
-      args.push(go_pkg)
     end
     args.push(opts)
 
@@ -96,4 +92,3 @@ module Go
     end
   end
 end
-

--- a/Support/gomate.rb
+++ b/Support/gomate.rb
@@ -22,11 +22,13 @@ module Go
     opts = {:use_hashbang => false, :version_args => ['version'], :version_regex => /\Ago version (.*)/}
     opts[:verb] = options[:verb] if options[:verb]
 
-    if command == 'run'
-      file_length = ENV['TM_DIRECTORY'].length + 1
-      go_file = ENV['TM_FILEPATH'][file_length..-1]
-      args.push(go_file)
-      opts[:chdir] = ENV['TM_DIRECTORY']
+    directory = ENV['TM_DIRECTORY']
+    if directory
+      opts[:chdir] = directory
+    end
+
+    if command == 'run' || !directory
+      args.push(ENV['TM_FILEPATH'])
     else
       # Default to running against directory, which in go should be the package
       # Useful for more cases, like install and build


### PR DESCRIPTION
When a new file is created but not saved, commands are not working as TM_DIRECTORY is not set. It's very handy to be able to run unsaved files to test some code snippets from the web etc.

Also, for non-run commands, we don't need to guess the package name and assume it's inside of the GOPATH. If we simply change current directory to the current package and run "go build" or "go test", it'll operate on the current package.