### PR TITLE
New path to godoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This bundle uses gocode for completion and godoc for documentation, which can be
 
 ```Shell
 go get -u github.com/nsf/gocode
-go get -u code.google.com/p/go.tools/cmd/godoc
+go get -u golang.org/x/tools/cmd/godoc
 ```
 
 This bundle uses goimports for cleaning up imports and reformatting code, which can be installed with:


### PR DESCRIPTION
Fixed warning:
```
warning: code.google.com is shutting down; import path code.google.com/p/go.tools/cmd/godoc will stop working
the code.google.com/p/go.tools/cmd/godoc command has moved; use golang.org/x/tools/cmd/godoc instead.
```