### PR TITLE
Don't save document before completion

### DIFF
--- a/Commands/Complete.tmCommand
+++ b/Commands/Complete.tmCommand
@@ -3,24 +3,34 @@
 <plist version="1.0">
 <dict>
 	<key>beforeRunningCommand</key>
-	<string>saveActiveFile</string>
+	<string>nop</string>
 	<key>command</key>
 	<string>#!/usr/bin/env ruby18
+
+require "open3"
+
 require ENV['TM_SUPPORT_PATH'] + '/lib/ui.rb'
 require ENV['TM_SUPPORT_PATH'] + "/lib/escape.rb"
 require ENV['TM_SUPPORT_PATH'] + "/lib/tm/require_cmd.rb"
 require ENV['TM_SUPPORT_PATH'] + "/lib/tm/htmloutput.rb"
 require ENV['TM_SUPPORT_PATH'] + "/lib/web_preview"
 
-# current document
+# load current document from stdin
 document = []
-File.open(ENV['TM_FILEPATH'], "r+") do |file|
-  document = file.readlines
+while line = $stdin.gets
+  document.push(line)
 end
 
 # byte offset of cursor position from the beginning of file
 cursor = document[ 0, ENV['TM_LINE_NUMBER'].to_i - 1].join().length + ENV['TM_LINE_INDEX'].to_i
-output = `"$TM_GOCODE" -f=csv -in=#{e_sh ENV['TM_FILEPATH']} autocomplete #{cursor}`
+
+# send document to stdin of gocode and read output
+output = ""
+Open3.popen3("\"$TM_GOCODE\" -f=csv autocomplete #{cursor}") {|stdin, stdout, stderr|
+  stdin.puts document.join
+  stdin.close
+  output = stdout.readlines.join
+}
 
 # quit if no completions found
 TextMate.exit_show_tool_tip("No completions found.") if output.length == 0
@@ -114,7 +124,7 @@ end</string>
 	<key>hideFromUser</key>
 	<string>true</string>
 	<key>input</key>
-	<string>none</string>
+	<string>document</string>
 	<key>inputFormat</key>
 	<string>text</string>
 	<key>keyEquivalent</key>


### PR DESCRIPTION
Fixing the indentation from gofmt like this:

<img width="188" alt="screen shot 2015-12-12 at 15 09 11" src="https://cloud.githubusercontent.com/assets/844117/11762068/bb62276e-a0e2-11e5-8285-86bf3e39396e.png">

Now godef utility uses stdin instead file on disk