### PR TITLE
Grammar: Fix var x = init(...) highlighting

### DIFF
--- a/Syntaxes/Go.tmLanguage
+++ b/Syntaxes/Go.tmLanguage
@@ -469,7 +469,7 @@
 					<key>comment</key>
 					<string>This matches the 'var x' style of variable declaration.</string>
 					<key>match</key>
-					<string>^\s*(var)\s+((?:[[:alpha:]_]\w*)(?:,\s+[[:alpha:]_]\w*)*)\s*(.*)\s*(?:=|$)</string>
+					<string>^\s*(var)\s+((?:[[:alpha:]_]\w*)(?:,\s+[[:alpha:]_]\w*)*)\s*(.*?)\s*(?:=|$)</string>
 					<key>name</key>
 					<string>meta.initialization.explicit.go</string>
 				</dict>


### PR DESCRIPTION
This fixes change introduced in a8328ab956a3f43b4aab72f860cc1eed3a7ecd1e that was adding type highlighting in `var x Type`. However the rule `(.*)\s*(?:=|$)` was greedy consuming everything until `=` or `$` (end of line). As a consequence it was effectively matching everything till end of line, consuming also `=` and everything that follows, resulting incorrect highlight, for eg.:

~~~go
var addr = flag.String("addr", ":8080", "TCP address to listen to")
~~~

Now replacing RE to use lazy (non-greedy) `(.*?)\s*(?:=|$)` rule.

FYI this is fixing bug that I have introduced, so take my apologies for introducing bug in first place.

### Before

![before](https://cloud.githubusercontent.com/assets/103067/11937735/84cea9f8-a816-11e5-9042-033da3d12382.png)

### After

![after](https://cloud.githubusercontent.com/assets/103067/11937740/8f186bc4-a816-11e5-9af3-8d8545f31c6e.png)
