### PR TITLE
Fixed error highlighting for argument index in *printf placeholders

### DIFF
--- a/Syntaxes/Go.tmLanguage
+++ b/Syntaxes/Go.tmLanguage
@@ -920,6 +920,7 @@
 					    [,;:_]?                                  # separator character (AltiVec)
 					    ((-?\d+)|\*(-?\d+\$)?)?                  # minimum field width
 					    (\.((-?\d+)|\*(-?\d+\$)?)?)?             # precision
+					    (\[\d+\])?                               # argument index
 					    [diouxXDOUeEfFgGaAcCsSpnvtTbyYhHmMzZq%]  # conversion type
 					</string>
 					<key>name</key>


### PR DESCRIPTION
Before fixing:
<img width="601" alt="screen shot 2017-04-06 at 9 10 55 pm" src="https://cloud.githubusercontent.com/assets/844117/24769262/8975ba70-1b0e-11e7-8280-05b10690f2ea.png">

After:
<img width="598" alt="screen shot 2017-04-06 at 9 11 20 pm" src="https://cloud.githubusercontent.com/assets/844117/24769268/9200cc34-1b0e-11e7-97df-1a784e47c7cd.png">
