### PR TITLE
Support imaginary literals

### DIFF
--- a/Syntaxes/Go.tmLanguage
+++ b/Syntaxes/Go.tmLanguage
@@ -549,7 +549,7 @@
 				</dict>
 				<dict>
 					<key>match</key>
-					<string>\b((0(x|X)[0-9a-fA-F]*)|((\d+\.?\d*)|(\.\d+))((e|E)(\+|-)?\d+)?)\b</string>
+					<string>\b((0(x|X)[0-9a-fA-F]*)|((\d+\.?\d*)|(\.\d+))((e|E)(\+|-)?\d+)?i?)\b</string>
 					<key>name</key>
 					<string>constant.numeric.go</string>
 				</dict>


### PR DESCRIPTION
Small fix to the `constant.numeric` scope to support [imaginary literals](https://golang.org/ref/spec#Imaginary_literals).

Examples (from the language spec):

```go
0i
011i
0.i
2.71828i
1.e+0i
6.67428e-11i
1E6i
.25i
.12345E+5i
```