### PR TITLE
fix var syntax highlighting with keyword 'type'

### DIFF
--- a/Syntaxes/Go.tmLanguage
+++ b/Syntaxes/Go.tmLanguage
@@ -1060,7 +1060,7 @@
 			</dict>
 			<key>match</key>
 			<string>(?x)
-			         ^\s*(type)\s*
+			         ^\s*(type)\s+
 			          (?:([[:upper:]]\w*)|([[:alpha:]_]\w*))           # name of type
 			          ((?:[\[\]\w\d\s\/,._*&amp;&lt;&gt;-]|(?:interface\{\}))*)? # other type
 			</string>


### PR DESCRIPTION
If defined a variable named 'typeVars', the chars 'type' highlighted as a keyword

fix @willfaught 's case in #36 