### PR TITLE
Use ruby18 for ruby commands

### DIFF
--- a/Commands/Build.tmCommand
+++ b/Commands/Build.tmCommand
@@ -7,10 +7,10 @@
 	<key>beforeRunningCommand</key>
 	<string>saveModifiedFiles</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby
+	<string>#!/usr/bin/env ruby18
 
 require "#{ENV['TM_BUNDLE_SUPPORT']}/gomate"
-Go::go "build", :verb => "Building"</string>
+Go::go "build", :verb =&gt; "Building"</string>
 	<key>input</key>
 	<string>document</string>
 	<key>inputFormat</key>

--- a/Commands/Documentation.tmCommand
+++ b/Commands/Documentation.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>saveModifiedFiles</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby
+	<string>#!/usr/bin/env ruby18
 
 require "#{ENV['TM_BUNDLE_SUPPORT']}/gomate"
 Go::gogetdoc

--- a/Commands/Install.tmCommand
+++ b/Commands/Install.tmCommand
@@ -7,10 +7,10 @@
 	<key>beforeRunningCommand</key>
 	<string>saveModifiedFiles</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby
+	<string>#!/usr/bin/env ruby18
 
 require "#{ENV['TM_BUNDLE_SUPPORT']}/gomate"
-Go::go "install", :verb => "Installing"</string>
+Go::go "install", :verb =&gt; "Installing"</string>
 	<key>input</key>
 	<string>document</string>
 	<key>inputFormat</key>

--- a/Commands/Lint.tmCommand
+++ b/Commands/Lint.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>saveActiveFile</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby
+	<string>#!/usr/bin/env ruby18
 
 require "#{ENV['TM_BUNDLE_SUPPORT']}/gomate"
 Go::golint

--- a/Commands/MetaLinter.tmCommand
+++ b/Commands/MetaLinter.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby
+	<string>#!/usr/bin/env ruby18
 
 require "#{ENV['TM_BUNDLE_SUPPORT']}/gomate"
 Go::gometalinter

--- a/Commands/Run.tmCommand
+++ b/Commands/Run.tmCommand
@@ -7,10 +7,10 @@
 	<key>beforeRunningCommand</key>
 	<string>saveModifiedFiles</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby
+	<string>#!/usr/bin/env ruby18
 
 require "#{ENV['TM_BUNDLE_SUPPORT']}/gomate"
-Go::go "run", :verb => "Running"
+Go::go "run", :verb =&gt; "Running"
 </string>
 	<key>input</key>
 	<string>document</string>

--- a/Commands/Test.tmCommand
+++ b/Commands/Test.tmCommand
@@ -7,10 +7,10 @@
 	<key>beforeRunningCommand</key>
 	<string>saveModifiedFiles</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby
+	<string>#!/usr/bin/env ruby18
 
 require "#{ENV['TM_BUNDLE_SUPPORT']}/gomate"
-Go::go "test", :verb => "Testing"
+Go::go "test", :verb =&gt; "Testing"
 </string>
 	<key>input</key>
 	<string>document</string>

--- a/Commands/Vet.tmCommand
+++ b/Commands/Vet.tmCommand
@@ -5,7 +5,7 @@
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>#!/usr/bin/env ruby
+	<string>#!/usr/bin/env ruby18
 
 require "#{ENV['TM_BUNDLE_SUPPORT']}/gomate"
 Go::go "vet", :verb =&gt; "Vetting"


### PR DESCRIPTION
TextMate library methods still depend on this version of ruby and the Mojave update was tripping up some of the commands due to the default ruby version.